### PR TITLE
fix cached token decode error

### DIFF
--- a/pkg/cache/file.go
+++ b/pkg/cache/file.go
@@ -3,12 +3,14 @@ package cache
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/10hin/cache-eks-creds/pkg/write_rename"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientauthn "k8s.io/client-go/pkg/apis/clientauthentication"
 	"os"
 	"path/filepath"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientauthn "k8s.io/client-go/pkg/apis/clientauthentication"
 )
 
 const (
@@ -86,20 +88,7 @@ func (c *fileCache) Update(profile, clusterName string, result string) error {
 		return err
 	}
 
-	var f *os.File
-	f, err = os.OpenFile(cachePath, os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-	defer func(f1 *os.File) {
-		err1 := f1.Close()
-		if err1 != nil {
-			fmt.Printf("error when cache file closing: %#v\n", err)
-		}
-	}(f)
-
-	_, err = f.WriteString(result)
-	return err
+	return write_rename.WriteRename(cachePath, strings.NewReader(result))
 }
 
 func (c *fileCache) Clear(profile, clusterName string) error {

--- a/pkg/write_rename/write_rename.go
+++ b/pkg/write_rename/write_rename.go
@@ -1,0 +1,30 @@
+package write_rename
+
+import (
+	"io"
+	"os"
+)
+
+func WriteRename(filePath string, content io.Reader) error {
+	var err error
+
+	var f *os.File
+	f, err = os.CreateTemp("", "")
+	if err != nil {
+		return err
+	}
+	tempFileName := f.Name()
+	defer func(filename string) {
+		// ignore error when removing.
+		// because if WriteRename succeed, filename file will not exist.
+		_ = os.Remove(filename)
+	}(tempFileName)
+
+	_, err = io.Copy(f, content)
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(tempFileName, filePath)
+
+}


### PR DESCRIPTION
before: open cache file without truncation
        (there remains gabage bytes in cache)
after: write new token to temporary file and rename it to cache path
       (new file never contain old cache gabage bytes)